### PR TITLE
Add Authorization option for eth1 readiness/liveness checks

### DIFF
--- a/clients/authorization.go
+++ b/clients/authorization.go
@@ -1,0 +1,33 @@
+package clients
+
+import (
+	"encoding/hex"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+type AuthorizationMethod string
+
+const (
+	None AuthorizationMethod = "bearer"
+	// Bearer Basic  AuthorizationMethod = "basic"
+	Bearer AuthorizationMethod = "bearer"
+)
+
+func CreateJWTAuthToken(jwtSecret string) (string, error) {
+	secret, err := hex.DecodeString(strings.TrimSpace(jwtSecret))
+	if err != nil {
+		return "", err
+	}
+
+	// TODO: caching strategy
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		NotBefore: jwt.NewNumericDate(time.Now()),
+	})
+	tokenString, err := token.SignedString(secret)
+	return tokenString, err
+}

--- a/config.yml
+++ b/config.yml
@@ -5,3 +5,5 @@ client:
     scheme: "http"
     host: "127.0.0.1"
     port: "8545"
+    authorizationType: ""
+    jwtSecret:

--- a/config/config.go
+++ b/config/config.go
@@ -16,9 +16,11 @@ type ServerConfig struct {
 }
 
 type ClientConfig struct {
-	Scheme string
-	Host   string
-	Port   string
+	Scheme            string
+	Host              string
+	Port              string
+	AuthorizationType string
+	JWTSecret         string
 }
 
 func NewConfig() (*Config, error) {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWp
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
 github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
+github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=


### PR DESCRIPTION
When Nethermind client has Engine API enabled default RPC endpoint requires authorization by default.

This PR adds possibility to specify authorization credentials.